### PR TITLE
fixed-support-ledger

### DIFF
--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -172,16 +172,20 @@ uiFuncs.generateTx = function(txData, callback) {
                             error: error
                         });
                         return;
+                    }else if (rawTx.chainId === 31102) {
+                        EIP155Supported = false; 
                     }
-                    var splitVersion = result['version'].split('.');
-                    if (parseInt(splitVersion[0]) > 1) {
-                        EIP155Supported = true;
-                    } else
-                    if (parseInt(splitVersion[1]) > 0) {
-                        EIP155Supported = true;
-                    } else
-                    if (parseInt(splitVersion[2]) > 2) {
-                        EIP155Supported = true;
+                    else	{
+                        var splitVersion = result['version'].split('.');
+                        if (parseInt(splitVersion[0]) > 1) {
+                            EIP155Supported = true;
+                        } else
+                        if (parseInt(splitVersion[1]) > 0) {
+                            EIP155Supported = true;
+                        } else
+                        if (parseInt(splitVersion[2]) > 2) {
+                            EIP155Supported = true;
+                        }
                     }
                     uiFuncs.signTxLedger(app, eTx, rawTx, txData, !EIP155Supported, callback);
                 }


### PR DESCRIPTION
fixed-support-ledger

add
~~~
+                    }else if (rawTx.chainId === 31102) {
+                        EIP155Supported = false; 
                     }
~~~
---
나노렛저 지원을 위해 업데이트를 하고자 함.
기존의 invalid sender 에러를 해결한다.
내부적으로 코드사이닝이 제대로 안되서 발생하는 문제.
칼리스토처럼 eip155를 꺼서 문제를 회피하였다.

http://wallet.gonspool.com 에서 전송테스트를 하였다.
실제 전송 테스트 TX : https://escblock.gonsmine.com/tx/0x32961c65e12f7baeae8dfd6f4b9072db31144c6b71fa026c4617d64969567e2a

관련 테스트 및 사용 정보는 https://www.ddengle.com/esn/8524861 에 작성하였습니다.